### PR TITLE
Improve mobile layout for skills and cards

### DIFF
--- a/src/components/SiteNavbar.tsx
+++ b/src/components/SiteNavbar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, NavLink, useNavigate, useLocation } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { Container, Nav, Navbar } from 'react-bootstrap';
 
 export default function SiteNavbar() {

--- a/src/styles/HomePage.css
+++ b/src/styles/HomePage.css
@@ -24,6 +24,18 @@
   gap: 1rem;
 }
 
+@media screen and (max-width: 768px) {
+  .competence-card {
+    width: 100%;
+    padding: 1rem;
+    font-size: 1rem;
+  }
+
+  .competences-grid {
+    gap: 1.25rem;
+  }
+}
+
 @media (min-width: 768px) {
   .competences-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/src/styles/MLGrid.css
+++ b/src/styles/MLGrid.css
@@ -86,6 +86,17 @@
   flex-wrap: wrap;
 }
 
+@media screen and (max-width: 768px) {
+  .ml-lab-card-teaser,
+  .ml-lab-tags-container {
+    display: none;
+  }
+
+  .ml-lab-card-body {
+    padding: 1rem;
+  }
+}
+
 /* Stile carosello SOLO per la HomePage su mobile */
 @media (max-width: 767px) {
   .home-carousel-section .ml-labs-grid {

--- a/src/styles/Projects.css
+++ b/src/styles/Projects.css
@@ -92,6 +92,17 @@
   font-weight: 600;
 }
 
+@media screen and (max-width: 768px) {
+  .project-card-description,
+  .project-tech-container {
+    display: none;
+  }
+
+  .project-card-body {
+    padding: 1rem;
+  }
+}
+
 /* ProjectsGrid Styles */
 .projects-grid {
   display: grid;


### PR DESCRIPTION
## Summary
- Refine skill cards for mobile with full-width layout, larger padding, and increased spacing
- Hide project and ML lab descriptions and tags on small screens to reduce card height
- Remove unused import in navbar to satisfy linting

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890cd477cac832eb826c3dbd8985c39