### PR TITLE
Refactor competence grid into reusable component

### DIFF
--- a/src/components/CompetencesGrid.tsx
+++ b/src/components/CompetencesGrid.tsx
@@ -1,0 +1,27 @@
+import type { Competence } from '../data/competences';
+
+interface Props {
+  competences: Competence[];
+}
+
+export default function CompetencesGrid({ competences }: Props) {
+  return (
+    <div className="competences-grid">
+      {competences.map((c, idx) => {
+        const Icon = c.icon;
+        return (
+          <div key={idx} className="col">
+            <div className="competence-card">
+              <div className="competence-icon">
+                <Icon aria-hidden="true" />
+              </div>
+              <div>
+                <strong>{c.title}:</strong> {c.detail}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/MLGrid.tsx
+++ b/src/components/MLGrid.tsx
@@ -31,15 +31,12 @@ export default function MLGrid({ limit }: MLGridProps) {
                 ))}
               </div>
               <div className="ml-lab-button-container">
-                <Button
-                  as={Link}
+                <Link
                   to={`/ml-labs/${lab.slug}`}
-                  size="sm"
-                  variant="info"
-                  className="text-dark fw-semibold"
+                  className="btn btn-info text-dark fw-semibold btn-sm"
                 >
                   Apri
-                </Button>
+                </Link>
                 {lab.repoUrl && (
                   <Button
                     href={lab.repoUrl}

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Container } from 'react-bootstrap';
 
 interface Props { 

--- a/src/components/SiteNavbar.tsx
+++ b/src/components/SiteNavbar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, NavLink, useNavigate, useLocation } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { Container, Nav, Navbar } from 'react-bootstrap';
 
 export default function SiteNavbar() {

--- a/src/data/competences.ts
+++ b/src/data/competences.ts
@@ -1,0 +1,25 @@
+import type { IconType } from 'react-icons';
+import { FaCode, FaDesktop, FaNetworkWired, FaDatabase, FaGlobe, FaMicrochip, FaRobot, FaProjectDiagram, FaShieldAlt, FaLanguage, FaTools, FaCogs, FaServer, FaCloud } from 'react-icons/fa';
+
+export interface Competence {
+  icon: IconType;
+  title: string;
+  detail: string;
+}
+
+export const competences: Competence[] = [
+  { icon: FaCode, title: 'Programmazione', detail: 'C, C++, Java, Python, Rust' },
+  { icon: FaDesktop, title: 'Sistemi Operativi', detail: 'OS161, Linux, Windows' },
+  { icon: FaNetworkWired, title: 'Reti di Calcolatori', detail: 'Protocolli, configurazione, sicurezza' },
+  { icon: FaDatabase, title: 'Basi di Dati', detail: 'SQL, PostgreSQL, MySQL' },
+  { icon: FaGlobe, title: 'Sviluppo Web', detail: 'HTML, CSS, JavaScript, Bootstrap' },
+  { icon: FaMicrochip, title: 'Microcontrollori', detail: 'Arduino, Raspberry Pi, LandTiger' },
+  { icon: FaRobot, title: 'AI & Machine Learning', detail: 'Supervised ML, deep learning, big data' },
+  { icon: FaProjectDiagram, title: 'Algoritmi & Strutture Dati', detail: 'Ordinamento, ricerca, heap, grafi' },
+  { icon: FaTools, title: 'DevOps & CI/CD', detail: 'Docker, GitHub Actions, pipeline automation' },
+  { icon: FaCogs, title: 'Software Engineering', detail: 'Design Patterns, metodologie Agile' },
+  { icon: FaServer, title: 'Kernel Internals', detail: 'Scheduling, memory management su OS/161' },
+  { icon: FaCloud, title: 'Cloud Basics', detail: 'AWS EC2/S3, GCP' },
+  { icon: FaShieldAlt, title: 'Cybersecurity', detail: 'Principi di sicurezza, mitigazioni' },
+  { icon: FaLanguage, title: 'Lingue', detail: 'Italiano (madrelingua), Inglese (C1)' },
+];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,30 +1,15 @@
 import React, { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import emailjs from '@emailjs/browser';
-import { FaCode, FaDesktop, FaNetworkWired, FaDatabase, FaGlobe, FaMicrochip, FaRobot, FaProjectDiagram, FaShieldAlt, FaLanguage, FaTools, FaCogs, FaServer, FaCloud } from 'react-icons/fa';
 import '../styles/HomePage.css';
 import Hero from '../components/Hero';
 import Section from '../components/Section';
 import ProjectsGrid from '../components/ProjectsGrid';
 import MLGrid from '../components/MLGrid';
+import CompetencesGrid from '../components/CompetencesGrid';
+import { competences } from '../data/competences';
 
 export default function HomePage() {
-  const competences = [
-    { icon: <FaCode />, title: 'Programmazione', detail: 'C, C++, Java, Python, Rust' },
-    { icon: <FaDesktop />, title: 'Sistemi Operativi', detail: 'OS161, Linux, Windows' },
-    { icon: <FaNetworkWired />, title: 'Reti di Calcolatori', detail: 'Protocolli, configurazione, sicurezza' },
-    { icon: <FaDatabase />, title: 'Basi di Dati', detail: 'SQL, PostgreSQL, MySQL' },
-    { icon: <FaGlobe />, title: 'Sviluppo Web', detail: 'HTML, CSS, JavaScript, Bootstrap' },
-    { icon: <FaMicrochip />, title: 'Microcontrollori', detail: 'Arduino, Raspberry Pi, LandTiger' },
-    { icon: <FaRobot />, title: 'AI & Machine Learning', detail: 'Supervised ML, deep learning, big data' },
-    { icon: <FaProjectDiagram />, title: 'Algoritmi & Strutture Dati', detail: 'Ordinamento, ricerca, heap, grafi' },
-    { icon: <FaTools />, title: 'DevOps & CI/CD', detail: 'Docker, GitHub Actions, pipeline automation' },
-    { icon: <FaCogs />, title: 'Software Engineering', detail: 'Design Patterns, metodologie Agile' },
-    { icon: <FaServer />, title: 'Kernel Internals', detail: 'Scheduling, memory management su OS/161' },
-    { icon: <FaCloud />, title: 'Cloud Basics', detail: 'AWS EC2/S3, GCP' },
-    { icon: <FaShieldAlt />, title: 'Cybersecurity', detail: 'Principi di sicurezza, mitigazioni' },
-    { icon: <FaLanguage />, title: 'Lingue', detail: 'Italiano (madrelingua), Inglese (C1)' }
-  ];
 
   const form = useRef<HTMLFormElement>(null);
   const [isSending, setIsSending] = useState(false);
@@ -67,18 +52,7 @@ export default function HomePage() {
 
         {/* Competenze grid */}
         <h3 className="h6 text-uppercase text-info mt-5 mb-3">Competenze principali</h3>
-        <div className="competences-grid">
-          {competences.map((c, idx) => (
-            <div key={idx} className="col">
-              <div className="competence-card">
-                <div className="competence-icon">{c.icon}</div>
-                <div>
-                  <strong>{c.title}:</strong> {c.detail}
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
+        <CompetencesGrid competences={competences} />
       </Section>
 
       <Section 


### PR DESCRIPTION
## Summary
- extract competences data into dedicated module and introduce reusable `CompetencesGrid` component
- clean navbar import and fix type-only imports
- simplify ML lab navigation link to avoid invalid Button typings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890cdcbefec832e8e8a3eb7fe26eeba